### PR TITLE
Migrated to abstract classes for the ones from `com.zeoflow.app`

### DIFF
--- a/flow-kit/src/main/java/com/zeoflow/app/Activity.java
+++ b/flow-kit/src/main/java/com/zeoflow/app/Activity.java
@@ -35,7 +35,7 @@ import com.zeoflow.zson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
 
-public class Activity extends AppCompatActivity
+public abstract class Activity extends AppCompatActivity
 {
 
     public Context zContext = ZeoFlowApp.getContext();

--- a/flow-kit/src/main/java/com/zeoflow/app/Fragment.java
+++ b/flow-kit/src/main/java/com/zeoflow/app/Fragment.java
@@ -33,7 +33,7 @@ import com.zeoflow.zson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
 
-public class Fragment extends androidx.fragment.app.Fragment
+public abstract class Fragment extends androidx.fragment.app.Fragment
 {
 
     public Context zContext;

--- a/flow-kit/src/main/java/com/zeoflow/app/FragmentActivity.java
+++ b/flow-kit/src/main/java/com/zeoflow/app/FragmentActivity.java
@@ -28,7 +28,7 @@ import com.zeoflow.log.Log;
 import com.zeoflow.log.PrettyFormatStrategy;
 import com.zeoflow.zson.Zson;
 
-public class FragmentActivity extends androidx.fragment.app.FragmentActivity
+public abstract class FragmentActivity extends androidx.fragment.app.FragmentActivity
 {
 
     public Context zContext;


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #40 
### Description
Since the elements under the *.app package are extendable then they should be abstract.

###### [Contributing](https://github.com/zeoflow/flow-kit/blob/master/docs/contributing.md) has more information and tips for a great pull request.