### PR TITLE
Fixed StringCreator fails on api 24 or lower

### DIFF
--- a/flow-kit/build.gradle
+++ b/flow-kit/build.gradle
@@ -37,13 +37,17 @@ dependencies {
     implementation 'com.zeoflow:material-elements:2.4.1'
     implementation 'com.zeoflow:stylar:1.1.0'
 
+    // todo remove this
     api 'com.facebook.conceal:conceal:1.1.3@aar'
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.fragment:fragment:1.3.2'
+
+    // todo remove this
     implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 
+    implementation("com.google.guava:guava:30.0-android")
     implementation("com.google.crypto.tink:tink-android:1.5.0")
 
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'

--- a/flow-kit/src/main/java/com/zeoflow/utils/string/StringCreator.java
+++ b/flow-kit/src/main/java/com/zeoflow/utils/string/StringCreator.java
@@ -33,7 +33,7 @@ public final class StringCreator
 {
 
     private static final Pattern NAMED_ARGUMENT =
-            Pattern.compile("\\$(?<argumentName>[\\w_]+):(?<typeChar>[\\w]).*");
+            Pattern.compile("\\$(" + Pattern.quote("?<argumentName>") + "[\\w_]+):(" + Pattern.quote("?<typeChar>") + "[\\w]).*");
     private static final Pattern LOWERCASE = Pattern.compile("[a-z]+[\\w_]*");
 
     /**

--- a/flow-kit/src/main/java/com/zeoflow/utils/string/StringWriter.java
+++ b/flow-kit/src/main/java/com/zeoflow/utils/string/StringWriter.java
@@ -31,7 +31,7 @@ final class StringWriter
     /**
      * Sentinel value that indicates that no user-provided package has been set.
      */
-    private static final Pattern LINE_BREAKING_PATTERN = Pattern.compile("\\R");
+    private static final Pattern LINE_BREAKING_PATTERN = Pattern.compile(Pattern.quote("\\R"));
 
     private final String indent;
     private final LineWrapper out;


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #72 
### Description
StringCreator fails on api 24 or lower

###### [Contributing](https://github.com/zeoflow/flow-kit/blob/master/docs/contributing.md) has more information and tips for a great pull request.