### PR TITLE
Fixed Invalid type for param from `StringCreator`

### DIFF
--- a/flow-kit/src/main/java/com/zeoflow/utils/string/StringCreator.java
+++ b/flow-kit/src/main/java/com/zeoflow/utils/string/StringCreator.java
@@ -414,6 +414,10 @@ public final class StringCreator
         private String argToName(Object o)
         {
             if (o instanceof CharSequence) return o.toString();
+            else if (o instanceof Integer) return o.toString();
+            else if (o instanceof Long) return o.toString();
+            else if (o instanceof Boolean) return o.toString();
+            else if (o instanceof Float) return o.toString();
             throw new IllegalArgumentException("expected name but was " + o);
         }
 


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #75
### Description
Fixed Invalid type for param from `StringCreator`

###### [Contributing](https://github.com/zeoflow/flow-kit/blob/master/docs/contributing.md) has more information and tips for a great pull request.